### PR TITLE
AuthorizationFactory required_params Bug Fix

### DIFF
--- a/anaplan_api/anaplan/authentication/AuthenticationFactory.py
+++ b/anaplan_api/anaplan/authentication/AuthenticationFactory.py
@@ -19,7 +19,7 @@ class AuthenticationFactory:
             )
 
         auth_class = AuthenticationFactory._auth_classes[method]
-        required_params = auth_class.required_params
+        required_params = set(auth_class.required_params)
 
         provided_params = set(kwargs.keys())
         missing_params = required_params - provided_params

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "anaplan-api"
-version = "0.2.8"
+version = "0.2.10"
 description = "A Python wrapper for the Anaplan Bulk API"
 authors = ["Jesse Wilson <jeswils@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
Bugfix in AuthorizationFactory caused by required_params property not being of type set. Casting to set to enable setwise operations.