### PR TITLE
[Fix] Issue #19

### DIFF
--- a/anaplan_api/anaplan/authentication/AuthenticationFactory.py
+++ b/anaplan_api/anaplan/authentication/AuthenticationFactory.py
@@ -19,7 +19,7 @@ class AuthenticationFactory:
             )
 
         auth_class = AuthenticationFactory._auth_classes[method]
-        required_params = set(auth_class.required_params)
+        required_params = auth_class.required_params
 
         provided_params = set(kwargs.keys())
         missing_params = required_params - provided_params

--- a/anaplan_api/anaplan/authentication/BasicAuthentication.py
+++ b/anaplan_api/anaplan/authentication/BasicAuthentication.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 class BasicAuthentication(AnaplanAuthentication):
-    _required_params: set = {"email", "password"}
+    required_params: set = {"email", "password"}
 
     """
     Represents a basic authentication header request
@@ -48,7 +48,3 @@ class BasicAuthentication(AnaplanAuthentication):
                 ]
             )
         }
-
-    @property
-    def required_params(self) -> set:
-        return self._required_params

--- a/anaplan_api/anaplan/authentication/CertificateAuthentication.py
+++ b/anaplan_api/anaplan/authentication/CertificateAuthentication.py
@@ -25,7 +25,7 @@ class CertificateAuthentication(AnaplanAuthentication):
     Represents a certificate authentication request
     """
 
-    _required_params: set = {"private_key", "certificate"}
+    required_params: set = {"private_key", "certificate"}
 
     # ===========================================================================
     # This function reads a user's public certificate as a string, base64
@@ -141,7 +141,3 @@ class CertificateAuthentication(AnaplanAuthentication):
         except ValueError as e:
             logger.error(f"Error loading private key {e}", exc_info=True)
             raise ValueError(f"Error loading private key {e}")
-
-    @property
-    def required_params(self) -> set:
-        return self._required_params


### PR DESCRIPTION
Remove required_params as protected class objects and reference directly instead of as a property. Cannot parse the returned object as a set, causing issues with error handling logic to ensure all required params have been set.