### PR TITLE
Pinned Deps Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,10 @@ dmypy.json
 *.zip
 *.sh
 testing.py
+
+#Keys & Certificates
+*.key
+*.der
+*.crt
+*.pem
+*.p12

--- a/README.md
+++ b/README.md
@@ -27,17 +27,16 @@ logger = logging.getLogger(__name__)
 if __name__ == '__main__':
     keys = KeystoreManager(path='/keystore.jks', passphrase='', alias='', key_pass='')
     
-    auth = anaplan.authorize("Basic", email="user@mail.com", password="password")
-    auth = anaplan.authorize("Certificate", private_key=keys.get_key(), certificate=keys.get_cert())
-    conn = AnaplanConnection(auth, "WorkspaceID", "ModelID")
+    auth = anaplan.authorize("Basic", email="{user@mail.com}", password="{password}")
+    auth = anaplan.authorize("Certificate", certificate=keys.get_cert(), private_key=keys.get_key(), password=b"{key_password}")
+    conn = AnaplanConnection(auth.auth_token, "{workspace_id}", "{model_id}")
 
-    anaplan.file_upload(conn=conn, file_id="", chunk_size=5, data='/Users.csv')
+    anaplan.file_upload(conn=conn, file_id="{file_id}", chunk_size=5, data='/Users.csv')
 
     results = anaplan.execute_action(conn=conn, action_id="", retry_count=3)
 
-    for result in results:
-        if result: # Boolean check of ParserResponse object, true if failure dump is available
-            print(result.error_dump)
+    for result in results.responses:
+        print(result.task_details)
 ```
 
 ## Contributing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.poetry]
 name = "anaplan-api"
-version = "0.2.14"
+version = "0.3.2"
 description = "A Python wrapper for the Anaplan Bulk API"
 authors = ["Jesse Wilson <jeswils@gmail.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.9"
-requests = "^2.32.0"
+requests = "^2.32.3"
 cryptography = "^42.0.8"
 idna = "^3.7"
 javaobj-py3 = "^0.4.3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ pyasn1-modules==0.3.0
 pycparser==2.21
 python-dateutil==2.9.0.post0
 pytz==2024.1
-requests==2.32.0
+requests==2.32.3
 six==1.16.0
 tzdata==2024.1
 urllib3==2.2.2


### PR DESCRIPTION
Update .gitignore to exclude keys/certificates. Update pyproject and requirements to resolved vulnerabilities in pinned deps. Update of README to reflect recent changes.